### PR TITLE
Check Empty Queue

### DIFF
--- a/R/getMessage.R
+++ b/R/getMessage.R
@@ -20,6 +20,9 @@ getMessage <- function(conn, queue, useJSON = F, blocking = F) {
     } else {
         message <- conn$RPOP(queue)
     }
+    if(is.null(message)) {
+        stop('No message found in queue')
+    }
     if(useJSON) {
         message <- jsonlite::fromJSON(message)
     } else {

--- a/tests/testthat/test-get-message.R
+++ b/tests/testthat/test-get-message.R
@@ -39,3 +39,14 @@ test_that('JSON messages that are pulled from the queue are appropriately deseri
     result
   )
 })
+
+test_that('error is thrown when no messages are in queue', {
+  skipIfNoRedis()
+  reduxConn <- testReduxConnection()
+  cleanQueue(reduxConn, 'emptyQueue')
+
+  expect_error(
+    getMessage(conn = reduxConn, queue = 'emptyQueue'),
+    'No message found in queue'
+  )
+})


### PR DESCRIPTION
These changes throw an informative error whenever a user tries to get a message from an empty/non-existent queue.

Fixes #18.