### PR TITLE
Pushing Should Occur on Left of Queue

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,6 @@
 export(getMessage)
 export(minionWorker)
 export(sendMessage)
-export(sendResponse)
 import(R.utils)
 import(Rbunyan)
 import(jsonlite)

--- a/R/sendMessage.R
+++ b/R/sendMessage.R
@@ -55,5 +55,5 @@ sendMessage <- function(conn, jobsQueue = "jobsQueue", package, func, parameters
     } else {
         job <- redux::object_to_bin(job)
     }
-    conn$RPUSH(jobsQueue, job)
+    conn$LPUSH(jobsQueue, job)
 }

--- a/R/sendResponse.R
+++ b/R/sendResponse.R
@@ -14,8 +14,6 @@
 #'
 #' @import redux jsonlite
 #'
-#' @export
-#'
 #' @param conn An open redux hiredis connection.
 #' @param queue A string giving the name of the queue where the response will be sent.
 #' @param status One of the following strings: "succeeded", "failed", or "catastrophic".
@@ -37,5 +35,5 @@ sendResponse <- function(conn, queue, status = c('succeeded', 'failed', 'catastr
     } else {
         job <- redux::object_to_bin(job)
     }
-    conn$RPUSH(queue, job)
+    conn$LPUSH(queue, job)
 }

--- a/tests/testthat/test-send-response.R
+++ b/tests/testthat/test-send-response.R
@@ -21,7 +21,7 @@ test_that('success responses can be sent and are of appropriate structure using 
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'succeeded',
@@ -45,7 +45,7 @@ test_that('failure responses can be sent and are of appropriate structure using 
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'failed',
@@ -69,7 +69,7 @@ test_that('unhandled error responses can be sent and are of appropriate structur
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'catastrophic',
@@ -93,7 +93,7 @@ test_that('success responses can be sent and are of appropriate structure using 
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'succeeded',
@@ -120,7 +120,7 @@ test_that('failure responses can be sent and are of appropriate structure using 
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'failed',
@@ -147,7 +147,7 @@ test_that('unhandled error responses can be sent and are of appropriate structur
 
     cleanQueue(reduxConn, 'testThatQueue')
 
-    sendResponse(
+    rminions:::sendResponse(
         reduxConn,
         'testThatQueue',
         'catastrophic',


### PR DESCRIPTION
Convert `RPUSH` commands to `LPUSH`. This set of changes also makes `sendResponse` a private function since it is really only used inside of `minionWorker`.

Fixes #24.